### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -18,6 +18,10 @@
 
 name: "Microsoft Defender For Devops"
 
+permissions:
+  contents: read
+  security-events: write
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/venkateshpabbati/kidney-disease-classification/security/code-scanning/4](https://github.com/venkateshpabbati/kidney-disease-classification/security/code-scanning/4)

To resolve the problem, add a `permissions` block at the root level of the workflow to restrict the `GITHUB_TOKEN` permissions to the least privileges required. Based on the workflow's functionality, it primarily reads code and uploads SARIF files. Thus, the permissions should be set to `contents: read` and `security-events: write`. This ensures the workflow can perform its tasks while minimizing security risks.

The following changes will occur:
1. Add a `permissions` block at the root level of the workflow file with the appropriate permissions.
2. No changes to the functionality of the workflow itself.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
